### PR TITLE
サーバ生成処理整理

### DIFF
--- a/app/bootstrap.ts
+++ b/app/bootstrap.ts
@@ -1,0 +1,22 @@
+import { Server } from 'http';
+import * as express from 'express';
+
+/**
+ * listenで起動可能なexpressアプリケーションを返す。
+ * 呼び出しごとに別のアプリケーションを生成することに注意。
+ * @author kbc14a12
+ */
+export function bootstrap():express.Application {
+    const app = express();
+    configureUse(app);
+    configureRoute(app);
+    return app;
+}
+
+function configureRoute(app: express.Application) {
+    // ルータをここに追加
+}
+
+function configureUse(app: express.Application) {
+    // ミドルウェアをここに追加
+}

--- a/app/conig/IServerConfig.ts
+++ b/app/conig/IServerConfig.ts
@@ -1,0 +1,4 @@
+export interface IServerConfig {
+    readonly port: number;
+    readonly host: string;
+}

--- a/config/deployment.json
+++ b/config/deployment.json
@@ -1,0 +1,6 @@
+{
+    "server": {
+        "host": "hoge",
+        "port": 80
+    }
+}

--- a/config/development.json
+++ b/config/development.json
@@ -1,0 +1,6 @@
+{
+    "server": {
+        "host": "localhost",
+        "port": 3000
+    }
+}

--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,13 @@
 import * as express from 'express';
 import * as smp from 'source-map-support';
 import { bootstrap } from './app/bootstrap';
+import * as config from 'config';
+import { IServerConfig } from './app/conig/IServerConfig';
+
+const serverConfig = config.get<IServerConfig>('server');
 
 smp.install();
 
-bootstrap().listen(80, () => {
-    console.log('Example app listening on port 80!');
+bootstrap().listen(serverConfig.port, serverConfig.host, () => {
+    console.log('Example app listening on port' + serverConfig.port);
 });

--- a/index.ts
+++ b/index.ts
@@ -1,10 +1,9 @@
 import * as express from 'express';
 import * as smp from 'source-map-support';
+import { bootstrap } from './app/bootstrap';
 
 smp.install();
 
-const app = express();
-
-app.listen(80, () => {
+bootstrap().listen(80, () => {
     console.log('Example app listening on port 80!');
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,12 @@
         "@types/node": "8.0.54"
       }
     },
+    "@types/config": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/config/-/config-0.0.33.tgz",
+      "integrity": "sha512-hoVW0qNMmhnBw14s25ROmY5TVXSB64iQlZldpoSKNtEydX5Mroyy5ZbquLnhh0VC4XlIw4kihMIOCIBSeVJhww==",
+      "dev": true
+    },
     "@types/diff": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-3.2.2.tgz",
@@ -479,6 +485,15 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "config": {
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/config/-/config-1.28.1.tgz",
+      "integrity": "sha1-diXSoeTJDxMdinM0eYLZPDhzKC0=",
+      "requires": {
+        "json5": "0.4.0",
+        "os-homedir": "1.0.2"
+      }
+    },
     "content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
@@ -889,6 +904,11 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
+    },
+    "json5": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+      "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -2732,6 +2752,11 @@
         "minimist": "0.0.10",
         "wordwrap": "0.0.3"
       }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "parse-passwd": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,14 @@
   },
   "homepage": "https://github.com/kbc-itw/BookChain#readme",
   "dependencies": {
+    "config": "^1.28.1",
     "express": "^4.16.2",
     "source-map-support": "^0.5.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.10",
     "@types/chai-http": "^3.0.3",
+    "@types/config": "0.0.33",
     "@types/express": "^4.0.39",
     "@types/mocha": "^2.2.44",
     "@types/sinon": "^4.1.2",
@@ -61,7 +63,7 @@
       "html",
       "text"
     ],
-    "sourceMap":true,
+    "sourceMap": true,
     "all": true
   }
-} 
+}

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "description": "図書貸し借りシステム",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --recursive --require ts-node/register \"test/**/*.ts\"",
-    "test:watch": "mocha --recursive --require ts-node/register \"test/**/*.ts\" --watch --watch-extensions ts",
-    "cover": "nyc npm t",
+    "test": "SET NODE_ENV=development&&mocha --recursive --require ts-node/register \"test/**/*.ts\"",
+    "test:watch": "SET NODE_ENV=development&&mocha --recursive --require ts-node/register \"test/**/*.ts\" --watch --watch-extensions ts",
+    "cover": "SET NODE_ENV=development&&nyc npm t NODE_ENV=development",
     "build": "tsc",
-    "start": "ts-node index.ts"
+    "start": "SET NODE_ENV=deployment&&ts-node index.ts",
+    "start:development": "SET NODE_ENV=development&&ts-node index.ts"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "test:watch": "SET NODE_ENV=development&&mocha --recursive --require ts-node/register \"test/**/*.ts\" --watch --watch-extensions ts",
     "cover": "SET NODE_ENV=development&&nyc npm t NODE_ENV=development",
     "build": "tsc",
-    "start": "SET NODE_ENV=deployment&&ts-node index.ts",
-    "start:development": "SET NODE_ENV=development&&ts-node index.ts"
+    "start": "SET NODE_ENV=deployment&&node index.js",
+    "start:development": "SET NODE_ENV=development&&node index.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test:watch": "mocha --recursive --require ts-node/register \"test/**/*.ts\" --watch --watch-extensions ts",
     "cover": "nyc npm t",
     "build": "tsc",
-    "start": "node index.js"
+    "start": "ts-node index.ts"
   },
   "repository": {
     "type": "git",

--- a/test/bootstrap.spec.ts
+++ b/test/bootstrap.spec.ts
@@ -2,15 +2,18 @@ import * as chai from 'chai';
 import 'mocha';
 import { bootstrap } from '../app/bootstrap';
 import { Server } from 'http';
+import * as config from 'config';
+import { IServerConfig } from '../app/conig/IServerConfig';
 
 chai.use(require('chai-http'));
 
 describe('bootstrap', () => {
+    const serverConfig = config.get<IServerConfig>('server');
 
     let server: Server;
 
     before((done) => {
-        server = bootstrap().listen(5000, () => done());
+        server = bootstrap().listen(serverConfig.port, serverConfig.host, () => done());
     });
 
     after((done) => {
@@ -24,5 +27,4 @@ describe('bootstrap', () => {
                 chai.expect(res).to.be.a('Object');
             });
     });
-
 });

--- a/test/bootstrap.spec.ts
+++ b/test/bootstrap.spec.ts
@@ -1,0 +1,28 @@
+import * as chai from 'chai';
+import 'mocha';
+import { bootstrap } from '../app/bootstrap';
+import { Server } from 'http';
+
+chai.use(require('chai-http'));
+
+describe('bootstrap', () => {
+
+    let server: Server;
+
+    before((done) => {
+        server = bootstrap().listen(5000, () => done());
+    });
+
+    after((done) => {
+        server.close(() => done());
+    });
+
+    it('サーバ起動に成功する', () => {
+        chai.request(server)
+            .get('/')
+            .end((err, res) => {
+                chai.expect(res).to.be.a('Object');
+            });
+    });
+
+});


### PR DESCRIPTION
## 何を実装/修正しますか？変更を説明してください。

Expressのアプリケーションサーバを生成する処理を関数として独立させた。
伴って、サーバが利用するポート番号やホスト名のハードコードを避けた。

## その他のコメント

scriptsにstart:developmentを追加した。開発環境で動かしてみる場合はこちらを利用すること。