### PR TITLE
セッション情報の永続化には別データベースを使う

### DIFF
--- a/app/bootstrap.ts
+++ b/app/bootstrap.ts
@@ -53,7 +53,7 @@ export function configureUse(app: express.Application) {
         resave: true,
         saveUninitialized: false,
         store: new (connectCouchDB(session))({
-            name: secret.couch.AUTH_DB_NAME,
+            name: secret.couch.SESSION_DB_NAME,
             username: secret.couch.USER_NAME,
             password: secret.couch.USER_PASSWORD,
             host: secret.couch.HOST,


### PR DESCRIPTION
ユーザーの認証情報を保存するためのAUTH_DB_NAMEで兼用していたが、できれば別データベースにするべきだと思うので変更。
