### PR TITLE
hfc-key-storeがgitignoreになかったため追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /config/secrets.json
+hfc-key-store
 
 ### IntelliJ IDEA ###
 .idea


### PR DESCRIPTION
しょうがないにゃぁ